### PR TITLE
Define a PI macro

### DIFF
--- a/src/rays.c
+++ b/src/rays.c
@@ -37,7 +37,7 @@ void init_sdl2(Context* ctx, const char* title, size_t width, size_t height) {
 
     size_t i = 0;
     for (double degree = -ctx->fov/2; degree <= ctx->fov/2 && i < RAY_COUNT; degree+=ctx->fov/RAY_COUNT, i++){
-        double rad = degree/360.0f * 2.0f*M_PI;
+        double rad = degree/360.0f * 2.0f*PI;
         ctx->rays[i].angle = rad;
         ctx->rays[i].len = RAY_LENGTH;
     }
@@ -84,12 +84,12 @@ void handle_events(Context* ctx){
                             ctx->keys[DOWN]  = -SDL_sinf(ctx->angle);
                         } break;
                         case SDLK_a: {
-                            ctx->keys[RIGHT] = SDL_cosf(ctx->angle - M_PI/2);
-                            ctx->keys[DOWN]  = SDL_sinf(ctx->angle - M_PI/2);
+                            ctx->keys[RIGHT] = SDL_cosf(ctx->angle - PI/2);
+                            ctx->keys[DOWN]  = SDL_sinf(ctx->angle - PI/2);
                         } break;
                         case SDLK_d: {
-                            ctx->keys[RIGHT] = SDL_cosf(ctx->angle + M_PI/2);
-                            ctx->keys[DOWN]  = SDL_sinf(ctx->angle + M_PI/2);
+                            ctx->keys[RIGHT] = SDL_cosf(ctx->angle + PI/2);
+                            ctx->keys[DOWN]  = SDL_sinf(ctx->angle + PI/2);
                         } break;
                         case SDLK_q: ctx->is_2d_view = !ctx->is_2d_view; break; 
                         default: break;
@@ -122,7 +122,7 @@ void handle_events(Context* ctx){
                     ctx->angle = SDL_atan2f(vy, vx);
                 } else {
                     float vx = target_x - WIDTH/2;
-                    ctx->angle = map(vx, -WIDTH/2, WIDTH/2, 0, M_PI);
+                    ctx->angle = map(vx, -WIDTH/2, WIDTH/2, 0, PI);
                     ctx->y_offset = target_y - HEIGHT/2;
                 }
             } break;

--- a/src/rays.h
+++ b/src/rays.h
@@ -24,6 +24,8 @@
 #define LEFT  2
 #define RIGHT 3
 
+#define PI 3.14159265359f
+
 typedef struct {
     float x;
     float y;


### PR DESCRIPTION
There's an issue with the rays.c file. It uses M_PI, a macro NOT supported by the C standard.
In fact, the standard does not guarantee a PI macro at all. 
I've added one to rays.h.
`#define PI 3.14159265359f`
There are other ways to get PI in C. 
Another one could be defining a constant like this.
`const PI = acos(-1.0);`
or
`const PI = (4.0 * atan(1.0));`
**NOTE:** do not define these two above as macros, as it would mean to call acos or atan once every time PI is used
in the code, wich will slow the program.
The program compiles and runs correctly and works as expected.
